### PR TITLE
Fix typo

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,5 +1,5 @@
 if(process.platform !== 'darwin') {
 	require('child_process').spawn('install.bat', [], { stdio:'inherit' });
 } else {
-	require('child_process').spawn('install.sh', [], { stdio:'inerit' });
+	require('child_process').spawn('install.sh', [], { stdio:'inherit' });
 }


### PR DESCRIPTION
`inerit` was meant to be to `inherit` probably, therefore `$ npm install chromium` fails on darwin:

```
default: throw new TypeError('Incorrect value of stdio option: ' + stdio);
               ^

TypeError: Incorrect value of stdio option: inerit
```
